### PR TITLE
Fixed bug with gallery layout on non-chromium browser

### DIFF
--- a/app/gallery/page.jsx
+++ b/app/gallery/page.jsx
@@ -8,7 +8,7 @@ export default function Gallery() {
 			<p className="text-4xl">Gallery</p>
 			<div className="p-8">
 				<SlideshowLightbox
-					className="columns-sm gap-4 space-y-4"
+					className="columns-sm [column-count:4] gap-4 space-y-4"
 					showControls={false}
 					iconColor={"#fffa"}
 					backgroundColor={"#000b"}


### PR DESCRIPTION
Previously, when the gallery was viewed on a non-chromium browser such as Firefox, the images would be shown in only one column. This does not follow the intended design of the gallery. The bug was fixed by explicitly specifying the maximum number of columns (4) that can be shown on the webpage.